### PR TITLE
Wrap the engine in a nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ target
 .vs
 bin
 build
+result
 
 generated.txt
 Water-Main.json

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -2,3 +2,4 @@
 Trevor Swan
 
 # Contributors
+SoloMazer

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,26 @@
+{
+  stdenv,
+  clang-tools,
+  python3,
+  ...
+}:
+
+stdenv.mkDerivation {
+  pname = "water";
+  version = "0.1.0";
+
+  src = ./.;
+
+  nativeBuildInputs = [
+    clang-tools
+    python3
+  ];
+
+  makeFlags = [ "dist" ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp bin/dist/water $out/bin/
+  '';
+
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1756542300,
+        "narHash": "sha256-tlOn88coG5fzdyqz6R93SQL5Gpq+m/DsWpekNFhqPQk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d7600c775f877cd87b4f5a831c28aa94137377aa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,24 @@
+{
+  description = "Nix Flake for Water-Engine: A C++ chess engine powered by magic bitboard and neural networks";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    {
+      nixpkgs,
+      ...
+    }:
+    let
+      system = "x86_64-linux";
+      pkgs = nixpkgs.legacyPackages.${system};
+      water-engine = pkgs.callPackage ./default.nix { };
+    in
+    {
+      packages.${system}.default = water-engine;
+      devShells.${system}.default = pkgs.mkShell {
+        inputsFrom = [ water-engine ];
+      };
+    };
+}


### PR DESCRIPTION
This commit provides a nix flake to run the engine on any system that has the nix package manager. This will allow the usage of `nix` commands like `nix shell`, `nix run`, `nix build` and others to quickly test the program. 

The code has been formatted with the official nixfmt, and packaged in standard "nix-way" by creating a default.nix and using `stdenv.mkDerivation`. No external flake inputs have been used, I am only using the latest nixpkgs. 

The flake is not super polished, I can probably make better use of nix, but its good enough for now. Goal is to package it properly (for eg, provide installation instructions etc) and include it in nixpkgs once the engine has a release. 